### PR TITLE
Optional params for private docker registry login

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The action packages, signs, and uploads the application to the specified ECR and
 | ecr-repo-name              | true     | The secret with the name of the ECR repo created by the app-container-repository stack | app-container-repository-tobytraining-containerrepository-i6gdfkdnwrrm               |
 | dockerfile                 | false     | The Dockerfile to use for the build | Dockerfile
 | checkout-repo                 | false     | Checks out the repo as the first step of the action. Default "true". | "true"
+| private-docker-registry | false | Private Docker registry URL. Default to "" | "abc12345.live.dynatrace.com"
+| private-docker-login-username | false | Login username to the private docker registry | "abc12345"
+| private-docker-login-password | false | Login password to the private docker registry | This should ideally be a GitHub secret
 
 ## Usage Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,18 @@ inputs:
     description: Checks out the repo as the first step of the action. Default "true".
     required: false
     default: "true"
+  private-docker-registry:
+    description: Private Docker registry URL
+    required: false
+    default: ""
+  private-docker-login-username:
+    description: Login username to the private docker registry
+    required: false
+    default: ""
+  private-docker-login-password:
+    description: Login password to the private docker registry
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -55,7 +67,17 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+          mask-password: 'true'
+
+    - name: Login to private Docker Registry
+      if: ${{ inputs.private-docker-registry != '' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.private-docker-registry }}
+        username: ${{ inputs.private-docker-login-username }}
+        password: ${{ inputs.private-docker-login-password }}
 
     - name: Install Cosign
       uses: sigstore/cosign-installer@main


### PR DESCRIPTION
## Description

Optional params for private docker registry login

New optional params introduced:
- private-docker-registry
- private-docker-login-username
- private-docker-login-password

Additional changes: upgraded to amazon-ecr-login@v2, and set mask-password: 'true' for additional security, as recommended by maintainers

### Ticket number
[PLAT-3005]
## Checklist

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by

[PLAT-3005]: https://govukverify.atlassian.net/browse/PLAT-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ