### PR TITLE
Plat 3225 - Add timestamp to artefact metadata in upload-action-ecr

### DIFF
--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -29,4 +29,4 @@ else
     echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
 fi
 zip template.zip cf-template.yaml
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA", mergetime=$MERGE_TIME"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,mergetime=$MERGE_TIME"

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -15,6 +15,8 @@ if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then
     cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
 fi
 
+MERGE_TIME=$(git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
+
 echo "Running sam build on template file"
 cd $WORKING_DIRECTORY
 sam build --template-file="$TEMPLATE_FILE"
@@ -27,4 +29,4 @@ else
     echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
 fi
 zip template.zip cf-template.yaml
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA", mergetime=$MERGE_TIME"


### PR DESCRIPTION
## Description
To allow the deployment times to measure the time of deployment from dev up until production, added mergetime timestamp to artifact’s metadata to upload-action-ecr script.

![Uploading Screenshot 2023-12-14 at 12.28.37.png…]()


### Ticket number
[PLAT-3225]
## Checklist

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by

[PLAT-3225]: https://govukverify.atlassian.net/browse/PLAT-3225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ