### PR TITLE
PLAT-3857 bump outdated actions in upload-action-ecr repo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
   steps:
     - name: Checkout repo
       if: ${{ inputs.checkout-repo == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v4

--- a/action.yaml
+++ b/action.yaml
@@ -55,12 +55,12 @@ runs:
       uses: actions/checkout@v4
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.8"
 
     - name: Set up AWS creds
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume-arn }}
         aws-region: eu-west-2


### PR DESCRIPTION
- Bump actions/checkout from v3 to v4
- Bump actions/setup-python from v4 to v5
- Bump aws-actions/configure-aws-credentials from v1-node16 to v4

PLAT-3857
## Checklist

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by