### PR TITLE
Adding option to configure the --platform tag during docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ The action packages, signs, and uploads the application to the specified ECR and
 
 ## Action Inputs
 
-| Input                      | Required | Description                                                                            | Example                                                                              |
-|----------------------------|----------|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| artifact-bucket-name       | true     | The secret with the name of the artifact S3 bucket                                     | artifact-bucket-1234                                                                 |
-| container-sign-kms-key-arn | false     | The secret with the name of the Signing Profile resource in AWS                        | signing-profile-1234                                                                 |
-| working-directory          | false    | The working directory containing the SAM app and the template file                     | ./sam-ecr-app                                                                        |
-| template-file              | false    | The name of the CF template for the application. This defaults to template.yaml        | custom-template.yaml                                                                 |
-| role-to-assume-arn         | true     | The secret with the GitHub Role ARN from the pipeline stack                            | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
-| ecr-repo-name              | true     | The secret with the name of the ECR repo created by the app-container-repository stack | app-container-repository-tobytraining-containerrepository-i6gdfkdnwrrm               |
-| dockerfile                 | false     | The Dockerfile to use for the build | Dockerfile
-| docker-build-path          | false     | The Dockerfile path to use for the build | Docker-build-path
-| checkout-repo                 | false     | Checks out the repo as the first step of the action. Default "true". | "true"
-| private-docker-registry | false | Private Docker registry URL. Default to "" | "abc12345.live.dynatrace.com"
-| private-docker-login-username | false | Login username to the private docker registry | "abc12345"
-| private-docker-login-password | false | Login password to the private docker registry | This should ideally be a GitHub secret
+| Input                         | Required | Description                                                                            | Example                                                                              |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| artifact-bucket-name          | true     | The secret with the name of the artifact S3 bucket                                     | artifact-bucket-1234                                                                 |
+| container-sign-kms-key-arn    | false    | The secret with the name of the Signing Profile resource in AWS                        | signing-profile-1234                                                                 |
+| working-directory             | false    | The working directory containing the SAM app and the template file                     | ./sam-ecr-app                                                                        |
+| template-file                 | false    | The name of the CF template for the application. This defaults to template.yaml        | custom-template.yaml                                                                 |
+| role-to-assume-arn            | true     | The secret with the GitHub Role ARN from the pipeline stack                            | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
+| ecr-repo-name                 | true     | The secret with the name of the ECR repo created by the app-container-repository stack | app-container-repository-tobytraining-containerrepository-i6gdfkdnwrrm               |
+| dockerfile                    | false    | The Dockerfile to use for the build                                                    | Dockerfile                                                                           |
+| docker-build-path             | false    | The Dockerfile path to use for the build                                               | Docker-build-path                                                                    |
+| docker-platform               | false    | The target architecture for the image build                                            | linux/amd64                                                                          |
+| checkout-repo                 | false    | Checks out the repo as the first step of the action. Default "true".                   | "true"                                                                               |
+| private-docker-registry       | false    | Private Docker registry URL. Default to ""                                             | "abc12345.live.dynatrace.com"                                                        |
+| private-docker-login-username | false    | Login username to the private docker registry                                          | "abc12345"                                                                           |
+| private-docker-login-password | false    | Login password to the private docker registry                                          | This should ideally be a GitHub secret                                               |
 
 ## Usage Example
 
@@ -41,10 +42,10 @@ Pull in the action in your workflow as below, making sure to specify the release
 
 - pre-commit:
 
-  ```shell
-  brew install pre-commit
-  pre-commit install -tpre-commit -tprepare-commit-msg -tcommit-msg
-  ```
+```shell
+brew install pre-commit
+pre-commit install -tpre-commit -tprepare-commit-msg -tcommit-msg
+```
 
 ## Releasing updates
 

--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,10 @@ inputs:
   docker-build-path:
     description: The Dockerfile path to use for the build
     required: false
+  docker-platform:
+    description: The target architecture for the image build
+    required: false
+    default: "linux/amd64"
   checkout-repo:
     description: Checks out the repo as the first step of the action. Default "true".
     required: false
@@ -69,7 +73,7 @@ runs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
       with:
-          mask-password: 'true'                            # pragma: allowlist secret
+        mask-password: "true" # pragma: allowlist secret
 
     - name: Login to private Docker Registry
       if: ${{ inputs.private-docker-registry != '' }}
@@ -82,7 +86,7 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: 'v1.9.0'
+        cosign-release: "v1.9.0"
 
     - name: Upload Fargates to S3
       env:
@@ -95,6 +99,7 @@ runs:
         ARTIFACT_BUCKET_NAME: ${{ inputs.artifact-bucket-name }}
         DOCKERFILE: ${{ inputs.dockerfile }}
         DOCKER_BUILD_PATH: ${{ inputs.docker-build-path }}
+        DOCKER_PLATFORM: ${{ inputs.docker-platform }}
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
 
       run: ${{ github.action_path }}/scripts/build-tag-push-ecr.sh

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -8,7 +8,12 @@ fi
 
 echo "Building image"
 
-docker build -t "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA" -f "$DOCKER_BUILD_PATH"/"$DOCKERFILE" "$DOCKER_BUILD_PATH"
+docker build \
+    --tag "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA" \
+    --platform "${DOCKER_PLATFORM}" \
+    --file "$DOCKER_BUILD_PATH"/"$DOCKERFILE" \
+    "$DOCKER_BUILD_PATH"
+
 docker push "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
 
 if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then


### PR DESCRIPTION
`v1.2.1` of this github action was causing deployments to Fargate to fail. https://github.com/govuk-one-login/devplatform-upload-action-ecr/pull/6

The deployment would fail as the new image which was pushed would now be able to start correctly with the error message: 

`Resource handler returned message: "Error occurred during operation 'ECS Deployment Circuit Breaker was triggered'." `. 

The fargate logs showed an `exec format error` which indicated that the docker image was built for the wrong architecture. 

The changes in 1.2.1 were to only upgrade the following actions:
- actions/checkout 
- actions/setup-python 
- aws-actions/cofigure-aws-credentials

Current theory is that one of these upgrades has altered which platform docker wants to build for. 

https://docs.docker.com/build/building/multi-platform/


### Ticket number
[PLAT-4215]

[PLAT-4215]: https://govukverify.atlassian.net/browse/PLAT-4215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ