### PR TITLE
Update build-tag-push-ecr.sh merge_time in utc

### DIFF
--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -33,8 +33,8 @@ fi
 GIT_TAG=$(git describe --tags --first-parent --always)
 # Cleaning the commit message to remove special characters
 COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
-# Gets merge time to main
-MERGE_TIME=$(git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
+# Gets merge time to main - displaying it in UTC timezone
+MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
 
 # Sanitise commit message and search for canary deployment instructions
 MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Update build-tag-push-ecr.sh merge_time in utc

this is the same change we made in: https://github.com/govuk-one-login/devplatform-upload-action


## Description

### Ticket number
[PLAT-4232]

## Checklist

- [x] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by

[PLAT-4232]: https://govukverify.atlassian.net/browse/PLAT-4232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ