### PR TITLE
Update build-tag-push-ecr.sh merge_time in utc

### DIFF
--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -34,7 +34,7 @@ GIT_TAG=$(git describe --tags --first-parent --always)
 # Cleaning the commit message to remove special characters
 COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
 # Gets merge time to main - displaying it in UTC timezone
-MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
+MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S')
 
 # Sanitise commit message and search for canary deployment instructions
 MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description
Update build-tag-push-ecr.sh merge_time in utc

PLAT-4232-update-mergetime

TESTING also in Jira.

Ubuntu 64 bit
root@9deb348eb7b2:/devplatform-demo-sam-app# uname -a
Linux 9deb348eb7b2 6.1.51-0-virt #1-Alpine SMP Mon, 04 Sep 2023 08:04:05 +0000 `x86_64` x86_64 x86_64 GNU/Linux

TZ=UTC0 git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S'
2024-04-24 `10:52:49`

`TZ=UTC0` git log -1 --format=%cd --date=`format-local`:'%Y-%m-%d %H:%M:%S'
2024-04-24 `09:52:49`

### Ticket number
[PLAT-4232]

## Checklist

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by

[PLAT-4232]: https://govukverify.atlassian.net/browse/PLAT-4232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ