### PR TITLE
PSREDEV-1080: Add version-number to pipeline metadata

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,10 @@ inputs:
     description: Login password to the private docker registry
     required: false
     default: ""
+  version-number:
+    description: The version number of the application being deployed. This defaults to ""'
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -102,6 +106,6 @@ runs:
         DOCKER_PLATFORM: ${{ inputs.docker-platform }}
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         GITHUB_ACTOR: ${{ github.actor }}
-
+        VERSION_NUMBER: ${{ inputs.version-number }}
       run: ${{ github.action_path }}/scripts/build-tag-push-ecr.sh
       shell: bash

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -56,4 +56,4 @@ else
     echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
 fi
 zip template.zip cf-template.yaml
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor=$GITHUB_ACTOR"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor=$GITHUB_ACTOR,release=$VERSION_NUMBER"


### PR DESCRIPTION
## Description

Update the upload-action-ecr to enable teams to set VERSION_NUMBER as a parameter, if no value is set there is a default of empty string.

Tested with version: https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/runs/9565195193/job/26367601701

Tested without version: https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/runs/9565267761

### Ticket number
[PSREDEV-1080](https://govukverify.atlassian.net/browse/PSREDEV-1080)

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Chanages:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please nofity teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [ ] Is my change backwards compatible? **_Please include evidence_**

- [ ] I have installed and run pre-commit

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-1080]: https://govukverify.atlassian.net/browse/PSREDEV-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ