### PR TITLE
PSREDEV-1157: Wrap 'commitauthor' in single quotes

### DIFF
--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -56,4 +56,4 @@ else
     echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
 fi
 zip template.zip cf-template.yaml
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor=$GITHUB_ACTOR,release=$VERSION_NUMBER"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"


### PR DESCRIPTION


## Description

Wraps the `commitauthor` metadata tag in single quotes to prevent issues when author's have square brackets in their name (e.g. `github-merge-queue[bot]`)

### Ticket number
[PSREDEV-1157]

## Testing evidence

Existing
```
aws s3 cp README.md s3://perftest-test-results-02a541244a66/README.md --metadata "author=github-merge-queue[bot]"

Error parsing parameter '--metadata': Expected: ',', received: ']' for input:
author=github-merge-queue[bot]
                             ^
```

Fix
```
aws s3 cp README.md s3://perftest-test-results-02a541244a66/README.md --metadata "author='github-merge-queue[bot]'"
upload: ./README.md to s3://perftest-test-results-02a541244a66/README.md
```

<img width="1141" alt="image" src="https://github.com/govuk-one-login/devplatform-upload-action-ecr/assets/110121463/0e314e96-d905-454e-aa52-f836bcc37e28">


[PSREDEV-1157]: https://govukverify.atlassian.net/browse/PSREDEV-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ