### PR TITLE
PSREDEV-1167 - Support sidecars in upload-action-ecr

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,4 +11,4 @@ rules:
 parserPreset:
   parserOpts:
     # sets the prefix that references-empty will look for
-    issuePrefixes: ['PLAT-']
+    issuePrefixes: ['PSREDEV-','PLAT-']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,7 @@ repos:
     rev: 'v6.2.1'
     hooks:
       - id: beautysh
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,12 +7,12 @@
 
 We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.
 
-### Non-breaking Chanages:
+### Non-breaking Changes:
 Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
 to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
 release v2.1.0 and point v2 to the same commit as v2.1.0.
 
-NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please nofity teams in the relevant slack channels.
+NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please notify teams in the relevant slack channels.
 
 ### Breaking Changes:
 Release a new major version as normal following semantic versioning.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ The action packages, signs, and uploads the application to the specified ECR and
 
 ## Action Inputs
 
-| Input                      | Required | Description                                                                            | Example                                                                              |
-|----------------------------|----------|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| artifact-bucket-name       | true     | The secret with the name of the artifact S3 bucket                                     | artifact-bucket-1234                                                                 |
-| container-sign-kms-key-arn | false     | The secret with the name of the Signing Profile resource in AWS                        | signing-profile-1234                                                                 |
-| working-directory          | false    | The working directory containing the SAM app and the template file                     | ./sam-ecr-app                                                                        |
-| template-file              | false    | The name of the CF template for the application. This defaults to template.yaml        | custom-template.yaml                                                                 |
-| role-to-assume-arn         | true     | The secret with the GitHub Role ARN from the pipeline stack                            | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
-| ecr-repo-name              | true     | The secret with the name of the ECR repo created by the app-container-repository stack | app-container-repository-tobytraining-containerrepository-i6gdfkdnwrrm               |
-| dockerfile                 | false     | The Dockerfile to use for the build | Dockerfile
-| checkout-repo                 | false     | Checks out the repo as the first step of the action. Default "true". | "true"
+| Input | Description | Required | Default | Example |
+| ----- | ----------- | -------- | ------- | ------- |
+| role-to-assume-arn | The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN | true | | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
+| container-sign-kms-key-arn | The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY | false | "none" | arn:aws:kms:eu-west-2:0123456789999:key/ab12cd34-6e5f-7gh8-i90j-05aaa12345ab |
+| build-and-push-image-only | Only run docker build, push and signing steps. Skip packaging and artifact uploads | false | "false" | |
+| template-file | The name of the CF template for the application. This defaults to template.yaml | false | template.yaml | custom-template.yaml |
+| working-directory | The working directory containing the app | false | . | ./sam-ecr-app |
+| artifact-bucket-name | The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_SOURCE_BUCKET_NAME | true | | artifact-bucket-1234 |
+| ecr-repo-name | The secret with the name of the ECR Repo (required) eg secrets.ECR_REPOSITORY | true | | app-container-repository-containerrepository-i6gdfkdnwrrm |
+| dockerfile | The Dockerfile to use for the build | false | Dockerfile | |
+| docker-build-path | The Dockerfile path to use for the build | false | | |
+| docker-platform | The target architecture for the image build | false | "" | |
+| checkout-repo | Checks out the repo as the first step of the action. Default "true".  | false | "true" | |
+| private-docker-registry | Private Docker registry URL | false | "" | |
+| private-docker-login-username | Login username to the private docker registry | false | "" | |
+| private-docker-login-password | Login password to the private docker registry | false | "" | |
+| push-latest-tag | Float 'latest' tag to the latest image version. This requires tag immutability disabled, a typical use case is test-image-repository containers | false | "false" | |
+| version-number | The version number of the application being deployed. This defaults to ""' | false | "" | |
 
 ## Usage Example
 
@@ -23,7 +31,7 @@ Pull in the action in your workflow as below, making sure to specify the release
 
 ```yaml
 - name: Deploy SAM app to ECR
-  uses: alphagov/di-devplatform-upload-action-ecr@<version_number>
+  uses: govuk-one-login/devplatform-upload-action-ecr@<version_number>
   with:
     artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
     container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
@@ -54,7 +62,7 @@ release v2.1.0 and point v2 to the same commit as v2.1.0.
 
 NOTE: Until v3 is released, you will need to point both v1 and v2 to the latest version since there are no breaking changes between them.
 
-NOTE: In regards to Dependabot subcribers, Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1) of a release ensure consumers are nofitied.
+NOTE: In regards to Dependabot subscribers, Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1) of a release ensure consumers are notified.
 
 ### Breaking changes
 
@@ -74,7 +82,7 @@ After you've merged the PR, then apply the correct tag for your release.
 Please ensure all pre-release versions have been tested prior to creation, you are able to do this via updating `uses:`
 property within a GitHub actions workflow to point to a branch name rather than the tag, see example below:
 
-```
+```yaml
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,7 @@ inputs:
     required: false
     default: ""
   push-latest-tag:
-    description: Float 'latest' tag to the latest image version. This requires tag immutability disabled, a typical use case are test-image-repository containers
+    description: Float 'latest' tag to the latest image version. This requires tag immutability disabled, a typical use case is test-image-repository containers
     required: false
     default: "false"
   version-number:

--- a/action.yaml
+++ b/action.yaml
@@ -53,6 +53,10 @@ inputs:
     description: Login password to the private docker registry
     required: false
     default: ""
+  push-latest-tag:
+    description: Float 'latest' tag to the latest image version. This requires tag immutability disabled, a typical use case are test-image-repository containers
+    required: false
+    default: "false"
   version-number:
     description: The version number of the application being deployed. This defaults to ""'
     required: false
@@ -101,7 +105,8 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         CONTAINER_SIGN_KMS_KEY_ARN: ${{ inputs.container-sign-kms-key-arn }}
         GITHUB_SHA: ${{ github.sha }}
-        BUILD_AND_PUSH_IMAGE_ONLY: ${{ inputs.build-and-push-image-only}}
+        PUSH_LATEST_TAG: ${{ inputs.push-latest-tag }}
+        BUILD_AND_PUSH_IMAGE_ONLY: ${{ inputs.build-and-push-image-only }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         TEMPLATE_FILE: ${{ inputs.template-file }}
         ECR_REPO_NAME: ${{ inputs.ecr-repo-name }}

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: "The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY"
     required: false
     default: "none"
+  build-and-push-image-only:
+    description: "Only run docker build, push and signing steps. Skip packaging and artifact uploads"
+    required: false
+    default: "false"
   template-file:
     description: "The name of the CF template for the application. This defaults to template.yaml"
     required: false
@@ -97,6 +101,7 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         CONTAINER_SIGN_KMS_KEY_ARN: ${{ inputs.container-sign-kms-key-arn }}
         GITHUB_SHA: ${{ github.sha }}
+        BUILD_AND_PUSH_IMAGE_ONLY: ${{ inputs.build-and-push-image-only}}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         TEMPLATE_FILE: ${{ inputs.template-file }}
         ECR_REPO_NAME: ${{ inputs.ecr-repo-name }}

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -67,9 +67,9 @@ if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then
         echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
     fi
 
-    if grep -q "GIT_SHA_PLACEHOLDER" cf-template.yaml; then
-        echo "Replacing \"GIT_SHA_PLACEHOLDER\" with new ECR image tag"
-        sed -i "s|GIT_SHA_PLACEHOLDER|$GITHUB_SHA|" cf-template.yaml
+    if grep -q "GIT-SHA-PLACEHOLDER" cf-template.yaml; then
+        echo "Replacing \"GIT-SHA-PLACEHOLDER\" with new ECR image tag"
+        sed -i "s|GIT-SHA-PLACEHOLDER|$GITHUB_SHA|" cf-template.yaml
     fi
 
     zip template.zip cf-template.yaml

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -29,31 +29,33 @@ if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then
     cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
 fi
 
-# This only gets set if there is a tag on the current commit.
-GIT_TAG=$(git describe --tags --first-parent --always)
-# Cleaning the commit message to remove special characters
-COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
-# Gets merge time to main - displaying it in UTC timezone
-MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S')
+if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then
+    # This only gets set if there is a tag on the current commit.
+    GIT_TAG=$(git describe --tags --first-parent --always)
+    # Cleaning the commit message to remove special characters
+    COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
+    # Gets merge time to main - displaying it in UTC timezone
+    MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S')
 
-# Sanitise commit message and search for canary deployment instructions
-MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
-if [[ $MSG =~ "[skip canary]" || $MSG =~ "[canary skip]" || $MSG =~ "[no canary]" ]]; then
-    SKIP_CANARY_DEPLOYMENT=1
-else
-    SKIP_CANARY_DEPLOYMENT=0
+    # Sanitise commit message and search for canary deployment instructions
+    MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
+    if [[ $MSG =~ "[skip canary]" || $MSG =~ "[canary skip]" || $MSG =~ "[no canary]" ]]; then
+        SKIP_CANARY_DEPLOYMENT=1
+    else
+        SKIP_CANARY_DEPLOYMENT=0
+    fi
+
+    echo "Running sam build on template file"
+    cd $WORKING_DIRECTORY
+    sam build --template-file="$TEMPLATE_FILE"
+    mv .aws-sam/build/template.yaml cf-template.yaml
+
+    if grep -q "CONTAINER-IMAGE-PLACEHOLDER" cf-template.yaml; then
+        echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with new ECR image ref"
+        sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA|" cf-template.yaml
+    else
+        echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
+    fi
+    zip template.zip cf-template.yaml
+    aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
 fi
-
-echo "Running sam build on template file"
-cd $WORKING_DIRECTORY
-sam build --template-file="$TEMPLATE_FILE"
-mv .aws-sam/build/template.yaml cf-template.yaml
-
-if grep -q "CONTAINER-IMAGE-PLACEHOLDER" cf-template.yaml; then
-    echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with new ECR image ref"
-    sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA|" cf-template.yaml
-else
-    echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
-fi
-zip template.zip cf-template.yaml
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -56,6 +56,12 @@ if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then
     else
         echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
     fi
+
+    if grep -q "GIT_SHA_PLACEHOLDER" cf-template.yaml; then
+        echo "Replacing \"GIT_SHA_PLACEHOLDER\" with new ECR image tag"
+        sed -i "s|GIT_SHA_PLACEHOLDER|$GITHUB_SHA|" cf-template.yaml
+    fi
+
     zip template.zip cf-template.yaml
     aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
 fi

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -17,13 +17,23 @@ else
     echo "No platform option supplied, using defaults."
 fi
 
+TAG_OPTION=""
+if [ "$PUSH_LATEST_TAG" == "true" ]; then
+    echo "Tagging option supplied $ECR_REGISTRY/$ECR_REPO_NAME:latest"
+    TAG_OPTION="--tag $ECR_REGISTRY/$ECR_REPO_NAME:latest"
+fi
+
 docker build \
     --tag "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA" \
+    $TAG_OPTION \
     $PLATFORM_OPTION \
     --file "$DOCKER_BUILD_PATH"/"$DOCKERFILE" \
     "$DOCKER_BUILD_PATH"
 
 docker push "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
+if [ "$PUSH_LATEST_TAG" == "true" ]; then
+    docker push "$ECR_REGISTRY/$ECR_REPO_NAME:latest"
+fi
 
 if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then
     cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"


### PR DESCRIPTION
## Description

1. Optional param to BUILD_AND_PUSH_IMAGE_ONLY
2. Conditional block to replace GIT_SHA_PLACEHOLDER
3. Optional param to enable latest tag push 

### Ticket number
[PSREDEV-1167]

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Chanages:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please nofity teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by


[PSREDEV-1167]: https://govukverify.atlassian.net/browse/PSREDEV-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ