### PR TITLE
PSREDEV-2237: Added artifact metadata closecircuitbreaker

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -115,6 +115,7 @@ runs:
         DOCKER_BUILD_PATH: ${{ inputs.docker-build-path }}
         DOCKER_PLATFORM: ${{ inputs.docker-platform }}
         COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, ' | ') }}
         GITHUB_ACTOR: ${{ github.actor }}
         VERSION_NUMBER: ${{ inputs.version-number }}
       run: ${{ github.action_path }}/scripts/build-tag-push-ecr.sh

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -48,11 +48,17 @@ if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then
     MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S')
 
     # Sanitise commit message and search for canary deployment instructions
-    MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
+    MSG=$(echo $COMMIT_MESSAGES | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
     if [[ $MSG =~ "[skip canary]" || $MSG =~ "[canary skip]" || $MSG =~ "[no canary]" ]]; then
         SKIP_CANARY_DEPLOYMENT=1
     else
         SKIP_CANARY_DEPLOYMENT=0
+    fi
+
+    if [[ $MSG =~ "[close circuit breaker]" || $MSG =~ "[end circuit breaker]" ]]; then
+        CLOSE_CIRCUIT_BREAKER=1
+    else
+        CLOSE_CIRCUIT_BREAKER=0
     fi
 
     echo "Running sam build on template file"
@@ -73,5 +79,5 @@ if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then
     fi
 
     zip template.zip cf-template.yaml
-    aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
+    aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,mergetime=$MERGE_TIME,skipcanary=$SKIP_CANARY_DEPLOYMENT,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER,closecircuitbreaker=$CLOSE_CIRCUIT_BREAKER"
 fi


### PR DESCRIPTION
## Description
- Metadata will be used by the pipeline to flag fixes and reenabled pipelines in case canary-circuit-breaker is active
- Search for special string in all commits being pushed to main as opposed to only the head commit. Valid for both circuit breaker and skip canary features
## Tests
- Deployment triggered by a push to a branch containing multiple commits
- Commits contain [skip canary] and [close circuit breaker]
![Screenshot 2025-04-04 at 16 10 15](https://github.com/user-attachments/assets/f2bddc48-0347-4b88-a05d-a92cbc004a9f)

### Ticket number
[PSREDEV-2237]

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Changes:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please notify teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit


[PSREDEV-2237]: https://govukverify.atlassian.net/browse/PSREDEV-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ