### PR TITLE
PSREDEV-2492: bump cosign to latest version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: "v1.9.0"
+        cosign-release: "v2.5.2"
 
     - name: Upload Fargates to S3
       env:


### PR DESCRIPTION
## Description
- cosign v1.9.0 is no longer supported by the installer
- this is stopping the action from running

Tested by running node-app deployment workflow with changes below:
https://github.com/govuk-one-login/devplatform-demo-sam-app/compare/main...refs/heads/PSREDEV-2494-testing
<img width="1075" alt="Screenshot 2025-07-04 at 08 56 42" src="https://github.com/user-attachments/assets/4e1f41a8-9a81-4bc4-8adf-c91f1c31e3d7" />


### Ticket number
[PSREDEV-2492]




[PSREDEV-2492]: https://govukverify.atlassian.net/browse/PSREDEV-2492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ