### PR TITLE
PSREDEV-3389: Add Cosign inputs to action.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ The action packages, signs, and uploads the application to the specified ECR and
 | ----- | ----------- | -------- | ------- | ------- |
 | role-to-assume-arn | The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN | true | | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
 | container-sign-kms-key-arn | The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY | false | "none" | arn:aws:kms:eu-west-2:0123456789999:key/ab12cd34-6e5f-7gh8-i90j-05aaa12345ab |
-| tlog-upload | Upload signing record to Rekor transparency log | false | "true" | |
+| tlog-upload | Upload signing record to Rekor transparency log, only available until Cosign v2 | false | "false" | |
 | cosign-version | The version of cosign to use for signing | false | "v3.0.6" | v3.0.6 |
-| cosign-installer | The version of cosign-installer to use for installing cosign | false | "v4.1.1" | v4.1.1 |
 | build-and-push-image-only | Only run docker build, push and signing steps. Skip packaging and artifact uploads | false | "false" | |
 | template-file | The name of the CF template for the application. This defaults to template.yaml | false | template.yaml | custom-template.yaml |
 | working-directory | The working directory containing the app | false | . | ./sam-ecr-app |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The action packages, signs, and uploads the application to the specified ECR and
 | ----- | ----------- | -------- | ------- | ------- |
 | role-to-assume-arn | The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN | true | | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
 | container-sign-kms-key-arn | The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY | false | "none" | arn:aws:kms:eu-west-2:0123456789999:key/ab12cd34-6e5f-7gh8-i90j-05aaa12345ab |
-| cosign-version | The version of cosign to use for signing | false | "v2.5.1" | v2.5.1 |
+| tlog-upload | Upload signing record to Rekor transparency log | false | "true" | |
+| cosign-version | The version of cosign to use for signing | false | "v3.0.5" | v3.0.5 |
+| cosign-installer | The version of cosign-installer to use for installing cosign | false | "v4.1.1" | v4.1.1 |
 | build-and-push-image-only | Only run docker build, push and signing steps. Skip packaging and artifact uploads | false | "false" | |
 | template-file | The name of the CF template for the application. This defaults to template.yaml | false | template.yaml | custom-template.yaml |
 | working-directory | The working directory containing the app | false | . | ./sam-ecr-app |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The action packages, signs, and uploads the application to the specified ECR and
 | role-to-assume-arn | The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN | true | | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
 | container-sign-kms-key-arn | The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY | false | "none" | arn:aws:kms:eu-west-2:0123456789999:key/ab12cd34-6e5f-7gh8-i90j-05aaa12345ab |
 | tlog-upload | Upload signing record to Rekor transparency log | false | "true" | |
-| cosign-version | The version of cosign to use for signing | false | "v3.0.5" | v3.0.5 |
+| cosign-version | The version of cosign to use for signing | false | "v3.0.6" | v3.0.6 |
 | cosign-installer | The version of cosign-installer to use for installing cosign | false | "v4.1.1" | v4.1.1 |
 | build-and-push-image-only | Only run docker build, push and signing steps. Skip packaging and artifact uploads | false | "false" | |
 | template-file | The name of the CF template for the application. This defaults to template.yaml | false | template.yaml | custom-template.yaml |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The action packages, signs, and uploads the application to the specified ECR and
 | ----- | ----------- | -------- | ------- | ------- |
 | role-to-assume-arn | The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN | true | | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
 | container-sign-kms-key-arn | The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY | false | "none" | arn:aws:kms:eu-west-2:0123456789999:key/ab12cd34-6e5f-7gh8-i90j-05aaa12345ab |
+| cosign-version | The version of cosign to use for signing | false | "v2.5.1" | v2.5.1 |
 | build-and-push-image-only | Only run docker build, push and signing steps. Skip packaging and artifact uploads | false | "false" | |
 | template-file | The name of the CF template for the application. This defaults to template.yaml | false | template.yaml | custom-template.yaml |
 | working-directory | The working directory containing the app | false | . | ./sam-ecr-app |

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: "The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY"
     required: false
     default: "none"
+  cosign-version:
+    description: "The version of cosign to use for signing. This defaults to v2.5.1"
+    required: false
+    default: "v2.5.1"
   build-and-push-image-only:
     description: "Only run docker build, push and signing steps. Skip packaging and artifact uploads"
     required: false
@@ -95,10 +99,11 @@ runs:
         username: ${{ inputs.private-docker-login-username }}
         password: ${{ inputs.private-docker-login-password }}
 
+    # Currently pinned to avoid numerous conflicts. See ticket: PSREDEV-3389
     - name: Install Cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@v3.10.1
       with:
-        cosign-release: "v3.0.3"
+        cosign-release: ${{ inputs.cosign-version }}
 
     - name: Upload Fargates to S3
       env:

--- a/action.yaml
+++ b/action.yaml
@@ -9,17 +9,13 @@ inputs:
     required: false
     default: "none"
   tlog-upload:
-    description: "Upload signing record to Rekor transparency log"
+    description: "Upload signing record to Rekor transparency log, only available until Cosign v2"
     required: false
-    default: "true"
+    default: "false"
   cosign-version:
     description: "The version of cosign to use for signing. This defaults to v3.0.6 which is currently the latest stable release"
     required: false
-    default: "v2.5.1"
-  cosign-installer:
-    description: "The version of the cosign installer action to use. This defaults to v4.1.1, which is currently the latest stable release"
-    required: false
-    default: "v4.1.1"
+    default: "v3.0.6"
   build-and-push-image-only:
     description: "Only run docker build, push and signing steps. Skip packaging and artifact uploads"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,9 @@ inputs:
     required: false
     default: "true"
   cosign-version:
-    description: "The version of cosign to use for signing. This defaults to v3.0.5 which is currently the latest stable release"
+    description: "The version of cosign to use for signing. This defaults to v3.0.6 which is currently the latest stable release"
     required: false
-    default: "v3.0.5"
+    default: "v2.5.1"
   cosign-installer:
     description: "The version of the cosign installer action to use. This defaults to v4.1.1, which is currently the latest stable release"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -8,10 +8,18 @@ inputs:
     description: "The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY"
     required: false
     default: "none"
-  cosign-version:
-    description: "The version of cosign to use for signing. This defaults to v2.5.1"
+  tlog-upload:
+    description: "Upload signing record to Rekor transparency log"
     required: false
-    default: "v2.5.1"
+    default: "true"
+  cosign-version:
+    description: "The version of cosign to use for signing. This defaults to v3.0.5 which is currently the latest stable release"
+    required: false
+    default: "v3.0.5"
+  cosign-installer:
+    description: "The version of the cosign installer action to use. This defaults to v4.1.1, which is currently the latest stable release"
+    required: false
+    default: "v4.1.1"
   build-and-push-image-only:
     description: "Only run docker build, push and signing steps. Skip packaging and artifact uploads"
     required: false
@@ -101,7 +109,7 @@ runs:
 
     # Currently pinned to avoid numerous conflicts. See ticket: PSREDEV-3389
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.10.1
+      uses: sigstore/cosign-installer@v4.1.1
       with:
         cosign-release: ${{ inputs.cosign-version }}
 
@@ -123,5 +131,6 @@ runs:
         COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, ' | ') }}
         GITHUB_ACTOR: ${{ github.actor }}
         VERSION_NUMBER: ${{ inputs.version-number }}
+        TLOG_UPLOAD: ${{ inputs.tlog-upload }}
       run: ${{ github.action_path }}/scripts/build-tag-push-ecr.sh
       shell: bash

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -36,7 +36,7 @@ if [ "$PUSH_LATEST_TAG" == "true" ]; then
 fi
 
 if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then
-    cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
+    cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA" --yes --tlog-upload=${TLOG_UPLOAD}
 fi
 
 if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then


### PR DESCRIPTION
## Description

After a Cosign upgrade in the Passport CRI pipeline, LIME team encountered a 409 conflict error when signing container images. The ECR upload action was overriding the workflow's Cosign version by using @ main and pulling the latest Cosign 3.0.4. This version has breaking changes where --tlog-upload=false is no longer supported. 

This PR adds inputs for:

`cosign version`
Setting the default as v.3.0.6 [Release v3.0.6 · sigstore/cosign](https://github.com/sigstore/cosign/releases/tag/v3.0.6) 

`cosign-installer`
Setting the default as: v.4.1.1 [Release v4.1.1 · sigstore/cosign-installer](https://github.com/sigstore/cosign-installer/releases/tag/v4.1.1) 

and: 

`tlog-upload`

which ensures transparency signing is kept internal. Confirmed with the team that this is not needed for our private ECRs.

These versions are the latest so will not introduce a breaking change. However, these values are now inputs so that teams can pin or override as needed.

Carried out tests to check that the default versions work, and also the requested cosign-version v.2.5.1 with cosign installer v.4.1.1

<img width="705" height="108" alt="Screenshot 2026-04-15 at 17 03 30" src="https://github.com/user-attachments/assets/87b9dfa5-dcec-4dd9-aab8-9f8b141438a0" />

<img width="824" height="297" alt="Screenshot 2026-04-15 at 17 09 16" src="https://github.com/user-attachments/assets/fc27362f-ef76-4433-81ab-97e945b00347" />

Testing using [this branch](https://github.com/govuk-one-login/devplatform-demo-sam-app/pull/596) node app, workflow, [`Node deploy using Environment secrets` workflow](https://github.com/govuk-one-login/devplatform-demo-sam-app/actions/workflows/node-deploy-using-environment-secrets.yml), within our govuk-one-login/devplatform-demo-sam-app repo.

### Ticket number
[PSREDEV-3389]

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Changes:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please notify teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [ ] I have installed and run pre-commit

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
**_Comment:_**

[PSREDEV-3389]: https://govukverify.atlassian.net/browse/PSREDEV-3389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ