### PR TITLE
Upgrade cosign to v3.0.6 and use signing config without tlog

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: "v3.0.3"
+        cosign-release: "v3.0.6"
 
     - name: Upload Fargates to S3
       env:

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -36,7 +36,8 @@ if [ "$PUSH_LATEST_TAG" == "true" ]; then
 fi
 
 if [ ${CONTAINER_SIGN_KMS_KEY_ARN} != "none" ]; then
-    cosign sign --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
+    curl -s https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json | jq 'del(.rekorTlogUrls)' > /tmp/signing-config.json
+    cosign sign --signing-config /tmp/signing-config.json --key "awskms:///${CONTAINER_SIGN_KMS_KEY_ARN}" "$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA"
 fi
 
 if [ "$BUILD_AND_PUSH_IMAGE_ONLY" == "false" ]; then


### PR DESCRIPTION
Cosign v3 requires a signing config file instead of CLI flags. The transparency log is not required for KMS-based signing and its absence caused verification failures, so it is excluded from the signing config.

## Description

When updating to the latest version of upload action ecr, all container signatures verifications are failing:
<img width="919" height="289" alt="image" src="https://github.com/user-attachments/assets/067507f9-c59b-40bc-9603-14bf724b3cd4" />

Logs showing verification failure due to failing to fetch trusted root
<img width="1157" height="300" alt="image" src="https://github.com/user-attachments/assets/bb55b11b-8c93-40df-9ae2-cf3fd45ffe2d" />

Cosign 3.06 version - https://github.com/sigstore/cosign/releases

Error when adding tlog-upload=false flag

```
Flag --tlog-upload has been deprecated, prefer using a --signing-config file with no transparency log services
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config. Provide a signing config with --signing-config without a transparency log service, which can be created with `cosign signing-config create` or `curl https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json | jq 'del(.rekorTlogUrls)'` for the public instance
error during command execution: --tlog-upload=false is not supported with --signing-config or --use-signing-config. Provide a signing config with --signing-config without a transparency log service, which can be created with `cosign signing-config create` or `curl https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json | jq 'del(.rekorTlogUrls)'` for the public instance
```

After updating this action and setting --insecure-ignore-tlog flag in container verifier stack
Linked PR - https://github.com/govuk-one-login/devplatform-container-verifier/pull/39

Note: Both changes need to be made for verification to be succeed.

<img width="1589" height="413" alt="image" src="https://github.com/user-attachments/assets/83cfd600-54a5-47d2-a03c-e7985831f7d8" />


### Ticket number
[PSREDEV-XXX]

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Changes:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please notify teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [ ] Is my change backwards compatible? **_Please include evidence_**

- [ ] I have installed and run pre-commit

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Automated tests added
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

- [ ] Delete any new stacks created for this ticket
**_Comment:_**

### Co-authored by
